### PR TITLE
[Fix] Link 태그 밑줄 생기는 문제

### DIFF
--- a/src/components/common/postCard/PostCard.styled.ts
+++ b/src/components/common/postCard/PostCard.styled.ts
@@ -8,6 +8,8 @@ export const CardWrapper = styled.li<{ $forDetail: boolean }>`
   background: ${({ theme }) => theme.colors.white1};
 
   a {
+    text-decoration: none;
+
     cursor: ${({ $forDetail }) => $forDetail && 'default'};
   }
   border: 1px solid ${({ theme, $forDetail }) => ($forDetail ? 'none' : theme.colors.gray6)};


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

### 📑 이슈 번호

<!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #175 

<br>

### ✨️ 작업 내용

<!-- 작업 내용을 간략히 설명해주세요 -->
일부 상황에서, Link로 씌워진 자식 요소인, Card 컴포넌트에 밑줄이 생기는 문제가 발생했습니다. 

Link 태그가 a 태그이기 때문에 아무래도 간혹, 브라우저 별 스타일 적용의 편차 혹은, 기존의 캐시 여부 등에 의해서 누군가는 밑줄이 생기고 누군가는 안 생기는 문제가 생겼던 것 같습니다. 

물론, 가장 큰 이유는 직접적으로 a 태그에 대해서 `text-decoration: none` 처리가 부재해서 생긴 일입니다! 따라서, 해당 컴포넌트의 a 태그에 대해서 위의 스타일 속성을 적용했습니다. 

<br>

### 💙 코멘트

<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->
제 컴퓨터에서는 정상 작동하기 때문에, 밑줄이 생기는 브라우저에서도 밑줄이 잘 사라지는지 확인하고 dev에 합칠 수 있도록 하겠습니다! 
~~(구현 결과, 이미지는 확인 후 첨부하겠습니다)~~

확인 완료 ☑️👍

<br>

### 📸 구현 결과

<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->

<!-- ⚠️⚠️⚠️⚠️⚠️⚠️ 잠깐 !!!! ⚠️⚠️⚠️⚠️⚠️ -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->

![image](https://github.com/user-attachments/assets/98f19bfa-5255-4708-b643-1b074619bf57)

