### PR TITLE
[Fix] 커뮤니티 목록 관련 QA 를 반영한다.

### DIFF
--- a/src/apis/board/queries.ts
+++ b/src/apis/board/queries.ts
@@ -10,7 +10,7 @@ export interface InfiniteQueryResponse {
   pageParams: number[];
 }
 
-export const useBoardScrap = (pickedtool?: number | null, noTopic?: boolean) => {
+export const useBoardScrap = (pickedtool?: number | null, noTopic?: boolean, boardId?: number) => {
   const userItem = localStorage.getItem('user');
   const userData = userItem ? JSON.parse(userItem) : null;
   const userId = userData?.accessToken || null;
@@ -64,7 +64,7 @@ export const useBoardScrap = (pickedtool?: number | null, noTopic?: boolean) => 
         return newBoardList;
       });
 
-      return { previousBoardList, updatedPopularList };
+      return { previousBoardList, updatedPopularList, previousDetail };
     },
     onError: (_error, _id, context) => {
       // 에러 발생 시 캐시 롤백
@@ -73,6 +73,9 @@ export const useBoardScrap = (pickedtool?: number | null, noTopic?: boolean) => 
       }
       if (context?.updatedPopularList) {
         queryClient.setQueryData(['boards', { noTopic: noTopic, toolId: pickedtool }], context.updatedPopularList);
+      }
+      if (context?.previousDetail && boardId) {
+        queryClient.setQueryData(['detailPost', boardId.toString()], context.updatedPopularList);
       }
       // handleModalOpen();
     },

--- a/src/apis/fetchPostList/api.ts
+++ b/src/apis/fetchPostList/api.ts
@@ -8,7 +8,7 @@ const fetchPostList = async ({
   queryKey,
 }: {
   pageParam: number | null | unknown;
-  queryKey: [string, { noTopic?: boolean; lastBoardId?: number | null; size?: number; toolId?: number | null }];
+  queryKey: [string, { noTopic?: boolean; size?: number; toolId?: number | null }];
 }): Promise<GetPostListResponse> => {
   try {
     const [, { noTopic, size, toolId }] = queryKey;

--- a/src/apis/fetchPostList/queries.ts
+++ b/src/apis/fetchPostList/queries.ts
@@ -6,11 +6,11 @@ import { fetchPostList } from './api';
 export const usePostListQuery = (toolId: number | null, noTopic: boolean) =>
   useInfiniteQuery<GetPostListResponse>({
     // 기본 쿼리 키 설정 (size에 따라서 가져올 값 갯수 결정가능 / toolId를 통해 필터링 가능 )
-    queryKey: ['boards', { noTopic, size: 10, lastBoardId: -1, toolId }],
+    queryKey: ['boards', { noTopic, toolId }],
     queryFn: ({ pageParam }) =>
       fetchPostList({
         pageParam,
-        queryKey: ['boards', { noTopic: noTopic, size: 10, lastBoardId: -1, toolId: toolId }],
+        queryKey: ['boards', { noTopic: noTopic, size: 10, toolId: toolId }],
       }),
 
     getNextPageParam: (lastPage) => {

--- a/src/components/common/postCard/PostCard.tsx
+++ b/src/components/common/postCard/PostCard.tsx
@@ -47,7 +47,7 @@ const Card = forwardRef<HTMLLIElement, CardDataProp>((props, ref) => {
   const [isImgModalOpen, setIsImgModalOpen] = useState(false);
   const [toastMessage, setToastMessage] = useState('');
 
-  const { isSuccess: isBookMarkSuccess, mutate: srapMutate } = useBoardScrap(pickedtool, noTopic);
+  const { isSuccess: isBookMarkSuccess, mutate: srapMutate } = useBoardScrap(pickedtool, noTopic, boardId);
 
   useEffect(() => {
     const postOwner = localStorage.getItem('user');

--- a/src/components/common/postCard/PostCard.tsx
+++ b/src/components/common/postCard/PostCard.tsx
@@ -119,6 +119,9 @@ const Card = forwardRef<HTMLLIElement, CardDataProp>((props, ref) => {
         onClick={(e) => {
           if (forDetail) {
             e.preventDefault();
+          } else {
+            sessionStorage.setItem('scrollPosition', window.scrollY.toString());
+            sessionStorage.setItem('toolType', pickedtool ? pickedtool.toString() : 'null');
           }
         }}
       >

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -77,7 +77,9 @@ const Community = () => {
           <ToolListBanner forCommunity={true} onToolSelect={handleToolSelect} originTool={initialTool} />
           <S.CardList>
             {postList && postList.length >= 1
-              ? postList?.map((post) => <Card key={`community-post-${post.boardId}`} post={post} />)
+              ? postList?.map((post) => (
+                  <Card key={`community-post-${post.boardId}`} post={post} noTopic={noTopic} pickedtool={pickedtool} />
+                ))
               : !isLoading && (
                   <S.NonTool>
                     <ImgPopupNonebookmarkScraptool />

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -61,13 +61,28 @@ const Community = () => {
   }, [inView]);
 
   useEffect(() => {
-    handleScrollUp();
+    const storedSrollPos = sessionStorage.getItem('scrollPosition');
+    const storedToolType = sessionStorage.getItem('toolType');
+
+    if (storedSrollPos) {
+      window.scrollTo(0, parseInt(storedSrollPos, 10));
+      sessionStorage.removeItem('scrollPosition');
+    }
+
+    if (storedToolType) {
+      const ToolType = storedToolType === 'null' ? null : Number(storedToolType);
+      setPickedtool(ToolType);
+      sessionStorage.removeItem('toolType');
+    } else {
+      handleScrollUp();
+    }
   }, [pickedtool, noTopic]);
 
   const handleToolSelect = (toolId: number | null, noTopic: boolean) => {
     setPickedtool(toolId);
     setIsNoTopic(toolId === null && noTopic);
   };
+
   return (
     <>
       <Title title="커뮤니티" />

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -5,52 +5,23 @@ import Loading from '@components/lottie/Loading';
 import Spacing from '@components/spacing/Spacing';
 import Title from '@components/title/Title';
 import { handleScrollUp } from '@utils';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import * as S from './Community.style';
 import Banner from './components/banner/Banner';
+import { useToolCategorySelect } from './hooks';
 
 import { usePostListQuery } from '../../apis/fetchPostList/queries';
 import Card from '../../components/common/postCard/PostCard';
 
 const Community = () => {
+  const { handleToolSelect, pickedtool, setPickedtool, noTopic, initialTool } = useToolCategorySelect();
+
   const navigate = useNavigate();
-  const [pickedtool, setPickedtool] = useState<number | null>(null);
-  const [noTopic, setIsNoTopic] = useState<boolean>(false);
   const { data, fetchNextPage, hasNextPage, isLoading } = usePostListQuery(pickedtool, noTopic);
   const { ref, inView } = useInView();
-  const location = useLocation();
-  const [originTool, setOriginTool] = useState<{
-    toolId: number | null;
-    toolLogo: string;
-    toolMainName: string;
-  }>();
-  const [initialTool, setInitialTool] = useState<{
-    toolId: number | null;
-    toolLogo: string;
-    toolName: string;
-  }>();
-
-  useEffect(() => {
-    if (location.state) {
-      setOriginTool(location.state);
-      if (originTool) {
-        setPickedtool(originTool?.toolId);
-      }
-    }
-  }, [location.state, originTool]);
-
-  useEffect(() => {
-    if (originTool) {
-      setInitialTool({
-        toolId: originTool.toolId,
-        toolName: originTool.toolMainName,
-        toolLogo: originTool.toolLogo,
-      });
-    }
-  }, [originTool]);
 
   const postList = data?.pages.map((item) => item.contents).flat();
 
@@ -60,6 +31,7 @@ const Community = () => {
     }
   }, [inView]);
 
+  // 스크롤 관련 로직
   useEffect(() => {
     const storedSrollPos = sessionStorage.getItem('scrollPosition');
     const storedToolType = sessionStorage.getItem('toolType');
@@ -77,11 +49,6 @@ const Community = () => {
       handleScrollUp();
     }
   }, [pickedtool, noTopic]);
-
-  const handleToolSelect = (toolId: number | null, noTopic: boolean) => {
-    setPickedtool(toolId);
-    setIsNoTopic(toolId === null && noTopic);
-  };
 
   return (
     <>

--- a/src/pages/community/hooks/index.ts
+++ b/src/pages/community/hooks/index.ts
@@ -1,3 +1,4 @@
 import useModal from './useModal';
+import useToolCategorySelect from './useToolCategorySelect';
 
-export { useModal };
+export { useModal, useToolCategorySelect };

--- a/src/pages/community/hooks/useToolCategorySelect.ts
+++ b/src/pages/community/hooks/useToolCategorySelect.ts
@@ -14,14 +14,12 @@ const useToolCategorySelect = () => {
 
   useEffect(() => {
     if (location.state) {
-      if (location.state) {
-        setPickedtool(location.state.toolId);
-        setInitialTool({
-          toolId: location.state.toolId,
-          toolName: location.state.toolMainName,
-          toolLogo: location.state.toolLogo,
-        });
-      }
+      setPickedtool(location.state.toolId);
+      setInitialTool({
+        toolId: location.state.toolId,
+        toolName: location.state.toolMainName,
+        toolLogo: location.state.toolLogo,
+      });
     }
   }, [location.state]);
 
@@ -36,6 +34,7 @@ const useToolCategorySelect = () => {
     setPickedtool,
     noTopic,
     initialTool,
+    setInitialTool,
   };
 };
 

--- a/src/pages/community/hooks/useToolCategorySelect.ts
+++ b/src/pages/community/hooks/useToolCategorySelect.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const useToolCategorySelect = () => {
+  const [pickedtool, setPickedtool] = useState<number | null>(null); // 카테고리 중 선택한 툴 정보 (자유일 경우 null)
+  const [noTopic, setIsNoTopic] = useState<boolean>(false); // 자유 게시판 선택 여부
+
+  const [initialTool, setInitialTool] = useState<{
+    toolId: number | null;
+    toolLogo: string;
+    toolName: string;
+  }>();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.state) {
+      if (location.state) {
+        setPickedtool(location.state.toolId);
+        setInitialTool({
+          toolId: location.state.toolId,
+          toolName: location.state.toolMainName,
+          toolLogo: location.state.toolLogo,
+        });
+      }
+    }
+  }, [location.state]);
+
+  const handleToolSelect = (toolId: number | null, noTopic: boolean) => {
+    setPickedtool(toolId);
+    setIsNoTopic(toolId === null && noTopic);
+  };
+
+  return {
+    handleToolSelect,
+    pickedtool,
+    setPickedtool,
+    noTopic,
+    initialTool,
+  };
+};
+
+export default useToolCategorySelect;


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

### 📑 이슈 번호

<!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #178 

<br>

### ✨️ 작업 내용
<!-- 작업 내용을 간략히 설명해주세요 -->

1. 글 목록 페이지에서, 커뮤니티 카드를 클릭하여 detail Page로 이동하기 전에 선택한 툴 카테고리 정보를 기록해서, 다시 목록으로 돌아갔을때에도 선택했던 카테고리에 머물며 마지막으로 봤던 스크롤로 돌아가도록 구현했습니다. 스크롤과 카테고리 정보는 `sessionStorage` 에 저장해서 창을 닫으면 사라질 수 있게 했습니다.

2. 커뮤니티 리스트와 세부 페이지의 북마크의 경우, 낙관적 업데이트를 진행하여 바로 결과가 보일 수 있도록 수정했습니다. query 파일에서 주석으로 둘 구분해놓았습니다. 

(목록 페이지로 다시 넘어오면서 카테고리 기억하면서 + 좌측에 있는 카테고리 바에도 반영하고 싶었는데 이건 컴포넌트 한번 리팩하면서 진행하는게 좋을 것 같아서 다음 이슈 파서 진행하도록 하겠습니다 )

<br>

### 💙 코멘트
<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->

마이페이지에서도 해당 로직을 사용하기 때문에, 잘 작동하는 것 확인하고 올렸습니다. 
혹시 모르니 다른 분들도 확인해주시면 좋을 것 같습니다. 

<br>

### 📸 구현 결과

<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->

https://github.com/user-attachments/assets/2ff6d535-2a74-4d09-82da-8b87e1b680a2


<!-- ⚠️⚠️⚠️⚠️⚠️⚠️ 잠깐 !!!! ⚠️⚠️⚠️⚠️⚠️ -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
